### PR TITLE
Update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Fulcrum [![Build Status](https://secure.travis-ci.org/fulcrumapp/fulcrum-ruby.png)](http://travis-ci.org/fulcrumapp/fulcrum-ruby)
+# Fulcrum [![Build Status](https://secure.travis-ci.org/fulcrumapp/fulcrum-ruby.svg)](http://travis-ci.org/fulcrumapp/fulcrum-ruby)
+
 
 Fulcrum API Gem
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fulcrum [![Build Status](https://secure.travis-ci.org/fulcrumapp/fulcrum-ruby.svg)](http://travis-ci.org/fulcrumapp/fulcrum-ruby)
+# Fulcrum [![Build Status](https://secure.travis-ci.org/fulcrumapp/fulcrum-ruby.svg)](http://travis-ci.org/fulcrumapp/fulcrum-ruby) [![Gem Version](https://badge.fury.io/rb/fulcrum.svg)](http://badge.fury.io/rb/fulcrum)
 
 
 Fulcrum API Gem


### PR DESCRIPTION
Use SVG for build status badge.
Add a badge for gem version. Helpful for knowing what the latest version is, without having to go to rubygems.