### PR TITLE
Mn001 adding audit logs to ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,14 @@ Format can be 'json', 'geojson', 'gpx', or 'kml'.
 
 
 
+## Audit Logs
+
+### client.audit_logs.all(params = {})
+
+### client.audit_logs.find(id)
+
+
+
 ## Extra Reading
 
 * [Fulcrum API documentation](http://fulcrumapp.com/developers/api/)

--- a/lib/fulcrum.rb
+++ b/lib/fulcrum.rb
@@ -24,4 +24,5 @@ require 'fulcrum/layer'
 require 'fulcrum/changeset'
 require 'fulcrum/webhook'
 require 'fulcrum/client'
+require 'fulcrum/audit_log'
 

--- a/lib/fulcrum/audit_log.rb
+++ b/lib/fulcrum/audit_log.rb
@@ -1,0 +1,6 @@
+module Fulcrum
+  class AuditLog < Resource
+    include Actions::List
+    include Actions::Find
+  end
+end

--- a/lib/fulcrum/client.rb
+++ b/lib/fulcrum/client.rb
@@ -124,5 +124,9 @@ module Fulcrum
     def webhooks
       @webhooks ||= Fulcrum::Webhook.new(self)
     end
+
+    def audit_logs
+      @audit_logs ||= Fulcrum::AuditLog.new(self)
+    end
   end
 end

--- a/spec/lib/audit_log_spec.rb
+++ b/spec/lib/audit_log_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+include Support::ResourceExamples
+
+describe Fulcrum::AuditLog do
+  include_context 'with client'
+  include_context 'with resource'
+
+  let(:resource) { client.audit_logs }
+
+  include_examples 'lists resource'
+  include_examples 'finds resource'
+end

--- a/spec/resource_examples.rb
+++ b/spec/resource_examples.rb
@@ -138,7 +138,7 @@ module Support
 
       it 'deletes a resource' do
         stub_request(:delete, member_url)
-          .to_return(status: 204, body: show_response,
+          .to_return(status: 204, body: nil,
                      headers: {"Content-Type" => "application/json"})
 
         object = resource.delete(resource_id)

--- a/spec/resource_examples.rb
+++ b/spec/resource_examples.rb
@@ -143,11 +143,9 @@ module Support
 
         object = resource.delete(resource_id)
 
-        puts object.inspect
-
         expect(client.response.status).to eq(204)
 
-        expect(object).to be_a(Hash)
+        expect(object).to be(nil)
       end
     end
   end

--- a/spec/resource_examples.rb
+++ b/spec/resource_examples.rb
@@ -143,6 +143,8 @@ module Support
 
         object = resource.delete(resource_id)
 
+        puts object.inspect
+
         expect(client.response.status).to eq(204)
 
         expect(object).to be_a(Hash)


### PR DESCRIPTION
Adds access to the Audit Log API endpoint and adds documentation for that to the library readme.