### PR TITLE
Potential fix for code scanning alert no. 1: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/lib/fulcrum/media_resource.rb
+++ b/lib/fulcrum/media_resource.rb
@@ -31,7 +31,7 @@ module Fulcrum
     end
 
     def download(url, &blk)
-      open(url, "rb", &blk)
+      URI.open(url, "rb", &blk)
     end
 
     def download_version(access_key, version, &blk)


### PR DESCRIPTION
Potential fix for [https://github.com/fulcrumapp/fulcrum-ruby/security/code-scanning/1](https://github.com/fulcrumapp/fulcrum-ruby/security/code-scanning/1) from the [Address initial critical SAST detections](https://github.com/orgs/fulcrumapp/security/campaigns/3) security campaign.

To fix the problem, we should replace the use of `Kernel.open` with a safer alternative. In this case, we can use the `URI.open` method, which is designed for opening URLs and does not have the same vulnerability as `Kernel.open`. This change will ensure that the input is handled securely without changing the existing functionality.

We need to modify the `download` method in the `lib/fulcrum/media_resource.rb` file to use `URI.open` instead of `open`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
