### PR TITLE
Potential fix for code scanning alert no. 2: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/lib/fulcrum/media_resource.rb
+++ b/lib/fulcrum/media_resource.rb
@@ -31,7 +31,7 @@ module Fulcrum
     end
 
     def download(url, &blk)
-      URI.open(url, "rb", &blk)
+      URI(url).open("rb", &blk)
     end
 
     def download_version(access_key, version, &blk)


### PR DESCRIPTION
Potential fix for [https://github.com/fulcrumapp/fulcrum-ruby/security/code-scanning/2](https://github.com/fulcrumapp/fulcrum-ruby/security/code-scanning/2)

To fix the problem, we should replace the use of `URI.open` with a safer alternative. The recommended approach is to use `URI(url).open` instead, which avoids the security vulnerability associated with `Kernel.open`. This change should be made in the `download` method of the `MediaResource` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
